### PR TITLE
Add ARCHIVE_PAGE configuration option

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -112,6 +112,9 @@ https://github.com/wamonite/relapse
                   {% for page_iter in pages if not page_iter.order %}
                 <li {% if page_iter == page %}class="active"{% endif %}><a href="{{ SITEURL }}/{{ page_iter.url }}">{{ page_iter.title }}</a></li>
                   {% endfor %}
+                    {% if ARCHIVE_PAGE == True %}
+                      <li {% if page_iter == page %}class="active"{% endif %}><a href="{{ SITEURL }}/archives.html">Archive</a></li>
+                    {% endif %}
                 {% endif %}
 
                 {% for title, link in MENUITEMS %}


### PR DESCRIPTION
This add the ability to enable an option to the config file to generate a link to the archives.html file, that is generated anyway.

One just add «ARCHIVE_PAGE = True» in the config and it generates an archive link on the menu bar.